### PR TITLE
Don't inject generic specs

### DIFF
--- a/src/mixer.erl
+++ b/src/mixer.erl
@@ -176,19 +176,12 @@ insert_stubs(Mixins, EOF, Forms) ->
     {EOF1, Forms ++ lists:reverse(lists:flatten(Stubs))}.
 
 generate_stub(Mixin, Alias, Name, Arity, CurrEOF) when Arity =< ?ARITY_LIMIT ->
-    AnyList = lists:duplicate(Arity, "any()"),
-    ArgTypeList = string:join(AnyList, ", "),
-    SpecCode = "-spec " ++ Alias ++ "(" ++ ArgTypeList ++ ") -> any().",
-    {ok, SpecTokens, _} = erl_scan:string(SpecCode),
-    {ok, SpecForm} = erl_parse:parse_form(SpecTokens),
-
     ArgList = "(" ++ make_param_list(Arity) ++ ")",
     Code = Alias ++ ArgList ++ "-> " ++ Mixin ++ ":" ++ Name ++ ArgList ++ ".",
     {ok, Tokens, _} = erl_scan:string(Code),
     {ok, Form} = erl_parse:parse_form(Tokens),
-    FunForm = replace_stub_linenum(CurrEOF, Form),
-    [FunForm, SpecForm].
-
+    replace_stub_linenum(CurrEOF, Form).
+    
 replace_stub_linenum(CurrEOF, {function, _, Name, Arity, Body}) ->
     {function, CurrEOF, Name, Arity, replace_stub_linenum(CurrEOF, Body, [])}.
 


### PR DESCRIPTION
This PR removes `spec` generation.  Since those specs are extremely generic (all args and return values are `any()`), they are not only redundant, but also break dialyzer checks while implementing `behaviour`.  This is because dialyzer requires that function's `spec` is defined as subtype of `callback` defined in `behaviour`. It will obviously fail since `any()` can not be subtype of anything beside `any()`.