### PR TITLE
Add new mixin type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,19 @@ One more version of `bar.erl` which mixes in `foo:doit/0` and renames it to `do_
     -module(bar).
     -include_lib("mixer/include/mixer.hrl").
     -mixin([{foo, [{doit/0, do_it_now}]}]).
+    
+Yet another version of `bar.erl` which mixes in all of `foo`'s public functions not implemented by `bar`.
+In this case the functions `foo:doit/0` and `foo:doit/1` will be injected into `bar`.
+
+```
+    -module(bar).
+    -include_lib("mixer/include/mixer.hrl").
+    -mixin([{foo, except, module}]).
+    -export([doit/2]).
+    
+    doit(A, B) ->
+        [bar_did_it, A, B].
+```
 
 The original motivation for this parse transform was to permit reuse of functions implementing common
 logic for tasks such as signature verification and authorization across multiple webmachine resources.

--- a/src/mixer.erl
+++ b/src/mixer.erl
@@ -30,30 +30,66 @@
                 alias,
                 arity}).
 
+-record(override_mixin, {line,
+                         mod,
+                         override_mod}).
+
 -spec parse_transform([term()], [term()]) -> [term()].
 parse_transform(Forms, _Options) ->
+    [set_mod_info(Form) || Form <- Forms],
     set_mod_info(Forms),
     {EOF, Forms1} = strip_eof(Forms),
-    case parse_and_expand_mixins(Forms1, []) of
-        [] ->
+    case parse_and_expand_mixins(Forms1, {[], []}) of
+        {[], _} ->
             Forms;
-        Mixins ->
-            no_dupes(Mixins),
-            {EOF1, Forms2} = insert_stubs(Mixins, EOF, Forms1),
-            finalize(Mixins, EOF1, Forms2)
+        {Mixins, Exports} ->
+            Mixins1 = inject_overrides(Mixins, lists:sort(Exports), []),
+            io:format("Mixins1: ~p~n", [Mixins1]),
+            no_dupes(Mixins1),
+            {EOF1, Forms2} = insert_stubs(Mixins1, EOF, Forms1),
+            finalize(Mixins1, EOF1, Forms2)
     end.
 
 %% Internal functions
-set_mod_info([{attribute, _, file, {FileName, _}}|_]) ->
+inject_overrides([], _Exports, Accum) ->
+    lists:reverse(Accum);
+inject_overrides([#override_mixin{line=Line, mod=Mod, override_mod=OverrideMod}|T], Exports, Accum)
+  when OverrideMod /= undefined->
+    case OverrideMod /= get_calling_mod() of
+        true ->
+            io:format(
+                "~s:~p Cannot override external modules (~p)~n",
+                [get_file_name(), Line, OverrideMod]),
+            exit({error, illegal_override_mod});
+        false ->
+            case sorted_mod_exports(Mod) -- Exports of
+                [] ->
+                    inject_overrides(T, Exports, Accum);
+                MixableExports ->
+                    ToInject = [#mixin{line=Line, mod=Mod, fname=FName, arity=Arity, alias=FName} ||
+                                   {FName, Arity} <- MixableExports],
+                    inject_overrides(T, Exports, ToInject ++ Accum)
+            end
+    end;
+inject_overrides([H|T], Exports, Accum) ->
+    inject_overrides(T, Exports, [H|Accum]).
+
+sorted_mod_exports(Mod) ->
+    lists:sort([{FName, Arity} || {FName, Arity} <- Mod:module_info(exports),
+                                  FName /= module_info]).
+
+set_mod_info({attribute, _, file, {FileName, _}}) ->
     erlang:put(mixer_delegate_file, FileName);
-set_mod_info([{attribute, _, module, Mod}|_]) ->
-    erlang:put(mixer_calling_mod, Mod).
+set_mod_info({attribute, _, module, Mod}) ->
+    erlang:put(mixer_calling_mod, Mod);
+set_mod_info(_) -> ok.
+
 
 get_file_name() ->
     erlang:get(mixer_delegate_file).
 
-%% get_calling_mod() ->
-%%     erlang:get(mixer_calling_mod).
+get_calling_mod() ->
+     erlang:get(mixer_calling_mod).
 
 finalize(Mixins, NewEOF, Forms) ->
     insert_exports(Mixins, Forms, []) ++ [{eof, NewEOF}].
@@ -79,14 +115,16 @@ strip_eof([{eof, EOF}|T], Accum) ->
 strip_eof([H|T], Accum) ->
     strip_eof(T, [H|Accum]).
 
-parse_and_expand_mixins([], []) ->
-    [];
-parse_and_expand_mixins([], Accum) ->
-    group_mixins({none, 0}, lists:keysort(2, Accum), []);
-parse_and_expand_mixins([{attribute, Line, mixin, Mixins0}|T], Accum)
+parse_and_expand_mixins([], {[], _}) ->
+    {[], []};
+parse_and_expand_mixins([], {Mixins, Exports}) ->
+    {group_mixins({none, 0}, lists:keysort(2, Mixins), []), Exports};
+parse_and_expand_mixins([{attribute, Line, mixin, Mixins0}|T], {Mixins, Exports})
   when is_list(Mixins0) ->
-    Mixins = [expand_mixin(Line, Mixin) || Mixin <- Mixins0],
-    parse_and_expand_mixins(T, lists:flatten([Accum, Mixins]));
+    Mixins1 = [expand_mixin(Line, Mixin) || Mixin <- Mixins0],
+    parse_and_expand_mixins(T, {lists:flatten([Mixins, Mixins1]), Exports});
+parse_and_expand_mixins([{attribute, _Line, export, Exports1}|T], {Mixins, Exports}) ->
+    parse_and_expand_mixins(T, {Mixins, lists:flatten(Exports, Exports1)});
 parse_and_expand_mixins([_|T], Accum) ->
     parse_and_expand_mixins(T, Accum).
 
@@ -97,6 +135,8 @@ group_mixins({CMod, CLine}, [#mixin{mod=CMod, line=CLine}=H|T], Accum) ->
 group_mixins({CMod, CLine}, [#mixin{mod=CMod}=H|T], Accum) ->
     group_mixins({CMod, CLine}, T, [H#mixin{line=CLine}|Accum]);
 group_mixins({_CMod, _}, [#mixin{mod=Mod, line=Line}=H|T], Accum) ->
+    group_mixins({Mod, Line}, T, [H|Accum]);
+group_mixins({Mod, Line}, [#override_mixin{}=H|T], Accum) ->
     group_mixins({Mod, Line}, T, [H|Accum]).
 
 expand_mixin(Line, Name) when is_atom(Name) ->
@@ -110,6 +150,9 @@ expand_mixin(Line, Name) when is_atom(Name) ->
             [#mixin{line=Line, mod=Name, fname=Fun, alias=Fun, arity=Arity}
              || {Fun, Arity} <- Exports, Fun /= module_info]
     end;
+expand_mixin(Line, {Name, except, OverrideMod}) when is_atom(Name),
+                                                      is_atom(OverrideMod) ->
+    [#override_mixin{line=Line, mod=Name, override_mod=OverrideMod}];
 expand_mixin(Line, {Name, except, Funs}) when is_atom(Name),
                                               is_list(Funs) ->
     case catch Name:module_info(exports) of
@@ -170,7 +213,8 @@ insert_stubs(Mixins, EOF, Forms) ->
              [  generate_stub(
                     atom_to_list(Mod), atom_to_list(Alias), atom_to_list(Fun),
                     Arity, CurrEOF) |Acc]
-            }
+            };
+            (#override_mixin{}, {CurrEOF, Acc}) -> {CurrEOF, Acc}
         end,
     {EOF1, Stubs} = lists:foldr(F, {EOF, []}, Mixins),
     {EOF1, Forms ++ lists:reverse(lists:flatten(Stubs))}.

--- a/test/import_test.erl
+++ b/test/import_test.erl
@@ -35,3 +35,13 @@ alias_test_() ->
      {<<"All stubbed functions work">>,
       [?_assertMatch(doit, alias:blah()),
        ?_assertMatch(true, alias:can_has())]}].
+
+override_test_() ->
+    [{<<"All non-overridden functions are stubbed">>,
+      [?_assert(lists:member({doit, 0}, ?EXPORTS(override))),
+       ?_assert(lists:member({doit, 1}, ?EXPORTS(override))),
+       ?_assert(lists:member({doit, 2}, ?EXPORTS(override)))]},
+     {<<"All functions work as expected">>,
+      [?_assertMatch(doit, override:doit()),
+       ?_assertMatch([5,5], override:doit(5)),
+       ?_assertMatch([doit, 5, 10], override:doit(5, 10))]}].

--- a/test/override.erl
+++ b/test/override.erl
@@ -1,0 +1,10 @@
+-module(override).
+
+-include("mixer.hrl").
+
+-mixin([{foo, except, ?MODULE}]).
+
+-export([doit/1]).
+
+doit(A) ->
+    [A, A].

--- a/test/override.erl
+++ b/test/override.erl
@@ -2,7 +2,7 @@
 
 -include("mixer.hrl").
 
--mixin([{foo, except, ?MODULE}]).
+-mixin([{foo, except, module}]).
 
 -export([doit/1]).
 


### PR DESCRIPTION
This PR introduces a new mixin type called an "override mixin". This isn't the greatest name but I couldn't come up with a better one :)

Syntactically an override mixin looks like this:

```
-mixin([{foo, except, module}]).
```
_Note the last element is the literal atom_ `module`.

Override mixins allows one module to mix in all functions from another *EXCEPT* for functions which are exported by the first module. 

See `test/foo.erl` and `test/overrides.erl` for a real example.