### PR TITLE
Use reserved words as function name

### DIFF
--- a/src/mixer.erl
+++ b/src/mixer.erl
@@ -199,7 +199,9 @@ insert_stubs(Mixins, EOF, Forms) ->
             #mixin{mod=Mod, fname=Fun, arity=Arity, alias=Alias} = Mixin,
             {CurrEOF + 1,
              [  generate_stub(
-                    atom_to_list(Mod), atom_to_list(Alias), atom_to_list(Fun),
+                    "'" ++ atom_to_list(Mod) ++ "'",
+                    "'" ++ atom_to_list(Alias) ++ "'",
+                    "'" ++ atom_to_list(Fun) ++ "'",
                     Arity, CurrEOF) |Acc]
             };
             (#override_mixin{}, {CurrEOF, Acc}) -> {CurrEOF, Acc}

--- a/src/mixer.erl
+++ b/src/mixer.erl
@@ -199,9 +199,9 @@ insert_stubs(Mixins, EOF, Forms) ->
             #mixin{mod=Mod, fname=Fun, arity=Arity, alias=Alias} = Mixin,
             {CurrEOF + 1,
              [  generate_stub(
-                    "'" ++ atom_to_list(Mod) ++ "'",
-                    "'" ++ atom_to_list(Alias) ++ "'",
-                    "'" ++ atom_to_list(Fun) ++ "'",
+                    binary_to_list(iolist_to_binary(io_lib:format("~p", [Mod]))),
+                    binary_to_list(iolist_to_binary(io_lib:format("~p", [Alias]))),
+                    binary_to_list(iolist_to_binary(io_lib:format("~p", [Fun]))),
                     Arity, CurrEOF) |Acc]
             };
             (#override_mixin{}, {CurrEOF, Acc}) -> {CurrEOF, Acc}

--- a/test/foo.erl
+++ b/test/foo.erl
@@ -1,7 +1,10 @@
 -module(foo).
 
 -export([doit/0, doit/1, doit/2]).
--export(['or'/2]).
+-export([
+  'or'/2, 'a-function'/1,
+  'CamelCaseFunction WithSpaces'/0, 'CamelCaseFunction WithSpaces'/1
+]).
 
 doit() ->
     doit.
@@ -14,3 +17,12 @@ doit(A, B) ->
 
 'or'(A, B) ->
     ['or', A, B].
+
+'a-function'(A) ->
+  [a_function, A].
+
+'CamelCaseFunction WithSpaces'() ->
+  [camel].
+
+'CamelCaseFunction WithSpaces'(A) ->
+  [camel, A].

--- a/test/foo.erl
+++ b/test/foo.erl
@@ -5,6 +5,8 @@
   'or'/2, 'a-function'/1,
   'CamelCaseFunction WithSpaces'/0, 'CamelCaseFunction WithSpaces'/1
 ]).
+-export(['\''/0, '\''/1, ''/0, ''/1]).
+-export(['🎱'/0, '🎱'/1]).
 
 doit() ->
     doit.
@@ -19,10 +21,28 @@ doit(A, B) ->
     ['or', A, B].
 
 'a-function'(A) ->
-  [a_function, A].
+    [a_function, A].
 
 'CamelCaseFunction WithSpaces'() ->
-  [camel].
+    [camel].
 
 'CamelCaseFunction WithSpaces'(A) ->
-  [camel, A].
+    [camel, A].
+
+'\''() ->
+    "why do you do this, kiddo?".
+
+'\''(This) ->
+    {This, is, devilish}.
+
+''() ->
+    ''(wat).
+
+''(Var) ->
+    {'🤯', Var}.
+
+'🎱'() ->
+    '🎱'('🙄').
+
+'🎱'(X) ->
+    {'not', X}.

--- a/test/foo.erl
+++ b/test/foo.erl
@@ -1,6 +1,7 @@
 -module(foo).
 
 -export([doit/0, doit/1, doit/2]).
+-export(['or'/2]).
 
 doit() ->
     doit.
@@ -10,3 +11,6 @@ doit(A) ->
 
 doit(A, B) ->
     [doit, A, B].
+
+'or'(A, B) ->
+    ['or', A, B].

--- a/test/import_test.erl
+++ b/test/import_test.erl
@@ -45,3 +45,8 @@ override_test_() ->
       [?_assertMatch(doit, override:doit()),
        ?_assertMatch([5,5], override:doit(5)),
        ?_assertMatch([doit, 5, 10], override:doit(5, 10))]}].
+
+reserved_test_() ->
+    [{<<"Use reserved words as function name">>,
+      [?_assertEqual(['or', "a", "b"], single:'or'("a", "b")),
+       ?_assertEqual(['or_2', "a", "b"], override:'or'("a", "b"))]}].

--- a/test/import_test.erl
+++ b/test/import_test.erl
@@ -51,11 +51,24 @@ reserved_test_() ->
       [?_assertEqual(['or', "a", "b"], single:'or'("a", "b")),
        ?_assertEqual(['or_override', "a", "b"], override:'or'("a", "b"))]}].
 
-invalid_atom_format_test_() ->
+strange_atom_format_test_() ->
     [{<<"Use non-alphanumeric atom as function name">>,
       [?_assertEqual(['a_function', "a"], single:'a-function'("a")),
        ?_assertEqual(['a_function_override', "a"], override:'a-function'("a")),
        ?_assertEqual(['camel'], single:'CamelCaseFunction WithSpaces'()),
        ?_assertEqual(['camel_override'], override:'CamelCaseFunction WithSpaces'()),
        ?_assertEqual(['camel', "a"], single:'CamelCaseFunction WithSpaces'("a")),
-       ?_assertEqual(['camel_override', "a"], override:'CamelCaseFunction WithSpaces'("a"))]}].
+       ?_assertEqual(['camel_override', "a"], override:'CamelCaseFunction WithSpaces'("a")),
+       ?_assertEqual("why do you do this, kiddo?", single:'\''()),
+       ?_assertEqual("why do you do this, kiddo?", override:'\''()),
+       ?_assertEqual({this, is, devilish}, single:'\''(this)),
+       ?_assertEqual({this, is, overridden}, override:'\''(this)),
+       ?_assertEqual({'🤯', wat}, single:''()),
+       ?_assertEqual({'🤯', wat}, override:''()),
+       ?_assertEqual({'🤯', "🧙‍♂️"}, single:''("🧙‍♂️")),
+       ?_assertEqual({overridden, "🧙‍♂️"}, override:''("🧙‍♂️")),
+       ?_assertEqual({'not', '🙄'}, single:'🎱'()),
+       ?_assertEqual({'not', '🙄'}, override:'🎱'()),
+       ?_assertEqual({'not', wat}, single:'🎱'(wat)),
+       ?_assertEqual({overridden, wat}, override:'🎱'(wat))
+       ]}].

--- a/test/import_test.erl
+++ b/test/import_test.erl
@@ -49,4 +49,13 @@ override_test_() ->
 reserved_test_() ->
     [{<<"Use reserved words as function name">>,
       [?_assertEqual(['or', "a", "b"], single:'or'("a", "b")),
-       ?_assertEqual(['or_2', "a", "b"], override:'or'("a", "b"))]}].
+       ?_assertEqual(['or_override', "a", "b"], override:'or'("a", "b"))]}].
+
+invalid_atom_format_test_() ->
+    [{<<"Use non-alphanumeric atom as function name">>,
+      [?_assertEqual(['a_function', "a"], single:'a-function'("a")),
+       ?_assertEqual(['a_function_override', "a"], override:'a-function'("a")),
+       ?_assertEqual(['camel'], single:'CamelCaseFunction WithSpaces'()),
+       ?_assertEqual(['camel_override'], override:'CamelCaseFunction WithSpaces'()),
+       ?_assertEqual(['camel', "a"], single:'CamelCaseFunction WithSpaces'("a")),
+       ?_assertEqual(['camel_override', "a"], override:'CamelCaseFunction WithSpaces'("a"))]}].

--- a/test/override.erl
+++ b/test/override.erl
@@ -9,6 +9,9 @@
   'or'/2, 'a-function'/1,
   'CamelCaseFunction WithSpaces'/0, 'CamelCaseFunction WithSpaces'/1
 ]).
+-export(['\''/1, ''/1]).
+-export(['🎱'/1]).
+
 
 doit(A) ->
     [A, A].
@@ -24,3 +27,12 @@ doit(A) ->
 
 'CamelCaseFunction WithSpaces'(A) ->
   [camel_override, A].
+
+'\''(This) ->
+    {This, is, overridden}.
+
+''(Var) ->
+    {overridden, Var}.
+
+'🎱'(X) ->
+    {overridden, X}.

--- a/test/override.erl
+++ b/test/override.erl
@@ -5,6 +5,10 @@
 -mixin([{foo, except, module}]).
 
 -export([doit/1]).
+-export(['or'/2]).
 
 doit(A) ->
     [A, A].
+
+'or'(A, B) ->
+    ['or_2', A, B].

--- a/test/override.erl
+++ b/test/override.erl
@@ -5,10 +5,22 @@
 -mixin([{foo, except, module}]).
 
 -export([doit/1]).
--export(['or'/2]).
+-export([
+  'or'/2, 'a-function'/1,
+  'CamelCaseFunction WithSpaces'/0, 'CamelCaseFunction WithSpaces'/1
+]).
 
 doit(A) ->
     [A, A].
 
 'or'(A, B) ->
-    ['or_2', A, B].
+    ['or_override', A, B].
+
+'a-function'(A) ->
+  [a_function_override, A].
+
+'CamelCaseFunction WithSpaces'() ->
+  [camel_override].
+
+'CamelCaseFunction WithSpaces'(A) ->
+  [camel_override, A].


### PR DESCRIPTION
When we tried to use function names like 'or', 'and', ... we encountered the next problem: 
(I guess it's bad practice, but possible to do)
```
 ./rebar eunit
==> inaka_mixer (eunit)
test/single.erl: error in parse transform 'mixer': {{badmatch,
                                    {error,
                                     {1,erl_parse,
                                      ["syntax error before: ","'or'"]}}},
                                   [{mixer,generate_stub,5,
                                     [{file,"src/mixer.erl"},{line,217}]},
                                    {mixer,'-insert_stubs/3-fun-0-',2,
                                     [{file,"src/mixer.erl"},{line,201}]},
                                    {mixer,insert_stubs,3,
                                     [{file,"src/mixer.erl"},{line,209}]},
                                    {mixer,parse_transform,2,
                                     [{file,"src/mixer.erl"},{line,47}]},
                                    {compile,
                                     '-foldl_transform/3-anonymous-2-',3,
                                     [{file,"compile.erl"},{line,1040}]},
                                    {compile,foldl_transform,3,
                                     [{file,"compile.erl"},{line,1043}]},
                                    {compile,'-internal_comp/5-anonymous-1-',
                                     3,
                                     [{file,"compile.erl"},{line,342}]},
                                    {compile,fold_comp,4,
                                     [{file,"compile.erl"},{line,369}]}]}
```
I checked the code and found the generate_stub was called with `"or"` and it tried to generate specs like `-spec or(any(), ...`

I added some unit test to try it, and small fix do add `'` around the Module/Fun/Alias names

Please check if it seems OK, or should not do this