### PR TITLE
Allow for analysis under rebar3_hank and rebar3_lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp_vsn: [20, 21, 22, 23, 24]
+        otp_vsn: [21, 22, 23, 24]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
@@ -22,7 +22,4 @@ jobs:
         with:
           otp-version: ${{matrix.otp_vsn}}
           rebar3-version: '3.14'
-      - run: rebar3 xref
-      - run: rebar3 dialyzer
-      - run: rebar3 eunit
-
+      - run: rebar3 test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ebin/*
 logs/
 *.beam
 _build/*
+doc/

--- a/elvis.config
+++ b/elvis.config
@@ -1,0 +1,13 @@
+[{elvis, [
+    {config, [
+        #{ dirs    => ["src", "test"]
+         , filter  => "*.erl"
+         , ruleset => erl_files }
+      , #{ dirs    => ["."]
+         , filter  => "rebar.config"
+         , ruleset => rebar_config }
+      , #{ dirs    => ["."]
+         , filter  => "elvis.config"
+         , ruleset => elvis_config }
+    ]}
+]}].

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,11 @@
            , debug_info
            ]}.
 
-{project_plugins, [rebar3_hex]}.
+{project_plugins, [
+    rebar3_hex,
+    rebar3_lint,
+    rebar3_hank
+]}.
 
 {cover_enabled, true}.
 {cover_opts, [verbose]}.
@@ -50,3 +54,5 @@
         ]}
     ]}
 ]}.
+
+{alias, [{test, [xref, dialyzer, lint, hank, eunit, ct, cover, edoc]}]}.

--- a/src/mixer.erl
+++ b/src/mixer.erl
@@ -22,6 +22,15 @@
 
 -export([parse_transform/2]).
 -ignore_xref(parse_transform/2).
+% ... since there's no behaviour for parse transformations
+-hank([{unnecessary_function_arguments, [parse_transform/2]}]).
+
+-elvis([{elvis_style, no_debug_call,
+                      #{ ignore => [{mixer, expand_mixin, 2},
+                                    {mixer, no_dupes, 2}] }}, % calls to io:format
+        {elvis_style, invalid_dynamic_call,
+                      #{ ignore => [{mixer, expand_mixin, 2},
+                                    {mixer, sorted_mod_exports, 1}] }}]). % calls to :module_info
 
 -define(ARITY_LIMIT, 26).
 
@@ -34,7 +43,8 @@
 -record(override_mixin, {line,
                          mod}).
 
--spec parse_transform([erl_parse:abstract_form() | erl_parse:form_info()], [compile:option()]) -> [term()].
+-spec parse_transform([erl_parse:abstract_form() | erl_parse:form_info()], [compile:option()])
+      -> [term()].
 parse_transform(Forms, _Options) ->
     lists:foreach(fun set_mod_info/1, Forms),
     set_mod_info(Forms),

--- a/test/failure_test.erl
+++ b/test/failure_test.erl
@@ -3,8 +3,9 @@
 -include_lib("kernel/include/file.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--define(EXPORTS(Mod), Mod:module_info(exports)).
 -define(EUNIT_TEMP_PATH, "_build/test/test_gen").
+
+-elvis([{elvis_style, dont_repeat_yourself, disable}]).
 
 duplicate_test_() ->
     [{<<"Duplicate mixins detected">>,
@@ -12,9 +13,9 @@ duplicate_test_() ->
               Mkdir = file:make_dir(?EUNIT_TEMP_PATH),
               ?assertEqual(ok, check_make_dir(Mkdir)),
               {ok, Path, Error} = compile_bad_test_file("duplicates"),
-              ?assertMatch({error,[{Path,
-                                    [{none,compile,
-                                      {parse_transform,mixer,{{error,duplicate_mixins}, _}}}]}],
+              ?assertMatch({error, [{Path,
+                                     [{none, compile,
+                                       {parse_transform, mixer, {{error, duplicate_mixins}, _}}}]}],
                             []}, Error) end}].
 
 conflicting_mixins_test_() ->
@@ -23,9 +24,9 @@ conflicting_mixins_test_() ->
               Mkdir = file:make_dir(?EUNIT_TEMP_PATH),
               ?assertEqual(ok, check_make_dir(Mkdir)),
               {ok, Path, Error} = compile_bad_test_file("conflicts"),
-              ?assertMatch({error,[{Path,
-                                    [{none,compile,
-                                      {parse_transform,mixer,{{error,duplicate_mixins}, _}}}]}],
+              ?assertMatch({error, [{Path,
+                                     [{none, compile,
+                                       {parse_transform, mixer, {{error, duplicate_mixins}, _}}}]}],
                             []}, Error) end}].
 
 %% Internal functions

--- a/test/foo.erl
+++ b/test/foo.erl
@@ -8,6 +8,8 @@
 -export(['\''/0, '\''/1, ''/0, ''/1]).
 -export(['🎱'/0, '🎱'/1]).
 
+-elvis([{elvis_style, function_naming_convention, disable}]).
+
 doit() ->
     doit.
 

--- a/test/import_test.erl
+++ b/test/import_test.erl
@@ -2,6 +2,9 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+% call to :module_info
+-elvis([{elvis_style, invalid_dynamic_call, #{ ignore => [{import_test, exports, 1}] }}]).
+
 single_test_() ->
     [{<<"All functions on 'single' stubbed properly">>,
      [?_assert(lists:member({doit, 0}, exports(single))),
@@ -41,7 +44,7 @@ override_test_() ->
        ?_assert(lists:member({doit, 2}, exports(override)))]},
      {<<"All functions work as expected">>,
       [?_assertMatch(doit, override:doit()),
-       ?_assertMatch([5,5], override:doit(5)),
+       ?_assertMatch([5, 5], override:doit(5)),
        ?_assertMatch([doit, 5, 10], override:doit(5, 10))]}].
 
 reserved_test_() ->
@@ -93,5 +96,5 @@ exports(Mod) -> Mod:module_info(exports).
 
 specs(Mod) ->
     Path = code:which(Mod),
-    {ok,{_,[{abstract_code,{_,AC}}]}} = beam_lib:chunks(Path, [abstract_code]),
+    {ok, {_, [{abstract_code, {_, AC}}]}} = beam_lib:chunks(Path, [abstract_code]),
     [{Fun, Arity} || {attribute, 1, spec, {{Fun, Arity}, _}} <- AC].

--- a/test/override.erl
+++ b/test/override.erl
@@ -12,6 +12,7 @@
 -export(['\''/1, ''/1]).
 -export(['🎱'/1]).
 
+-elvis([{elvis_style, function_naming_convention, disable}]).
 
 doit(A) ->
     [A, A].


### PR DESCRIPTION
This'll require `elvis_core`'s [most recent](https://github.com/inaka/elvis_core/pull/202) pull [requests merged](https://github.com/inaka/elvis_core/pull/203), tagged and published, since local development benefited from `_checkouts` 😄.